### PR TITLE
Use the WOA23 download in av17 instead of ik11

### DIFF
--- a/inte.csh
+++ b/inte.csh
@@ -25,11 +25,11 @@
 source /etc/profile.d/modules.csh
 
 module purge
-module use /g/data/hh5/public/modules
+module use /g/data/xp65/public/modules
 module load conda/analysis3
 module load nco
 
-set src_dir = /g/data/ik11/inputs/WOA23
+set src_dir = /g/data/av17/access-nri/OM3/woa23
 set dst_dir = /g/data/ik11/inputs/access-om3/woa23/monthly/`date +"%Y.%m.%d"`
 
 mkdir -p $dst_dir
@@ -82,6 +82,6 @@ ncrename -v s_an,practical_salinity $dst_dir/woa23_decav_ts_`printf "%02d" {$imo
 @ imon ++
 end
 
-echo 'processing conservative temperature'
+echo 'processing salinities and temperatures'
 time python3 setup_WOA_initial_conditions.py $src_dir/ $dst_dir/
 


### PR DESCRIPTION
@chrisb13 noted that there are downloads of WOA23 in both `ik11` and `av17`. This PR updates the initial condition generation workflow to use the `av17` data rather than `ik11`.

~@chrisb13 I'm a little worried that the `av17` data is in a directory called `access-nri-temporary`? Is this likely to change? Are we sure we want to do this?~ This has now been renamed to `access-nri` after consultation with the MED team