### PR TITLE
Parallelising make_initial_conditions.sh to run quicker on large grid.

### DIFF
--- a/initial_conditions_WOA23/README.md
+++ b/initial_conditions_WOA23/README.md
@@ -6,5 +6,5 @@ This repository contains the tools and scripts to generate initial condition fil
 
 This script generates initial condition files for a specific MOM ocean grid using WOA23 data. The grid and data paths are provided as environment variables, execute the following script with the grid, input and output directories as a command-line argument:
 
-`qsub -v VGRID="<path_to_vgrid_file>",HGRID="<path_to_hgrid_file>",INPUT_DIR="<path_to_input_directory>",OUTPUT_DIR="<path_to_output_directory>" -P $PROJECT make_initial_conditions.sh`
+`./make_initial_conditions.sh --vgrid /g/data/vk83/configurations/inputs/access-om3/mom/grids/vertical/global.25km/2025.03.12/ocean_vgrid.nc --hgrid /g/data/x77/ahg157/inputs/mom6/global-8km/ocean_hgrid.nc --input /g/data/ik11/inputs/access-om3/woa23/monthly/2025.10.24 --output /g/data/tm70/cyb561/8km_woa_ic`
 

--- a/initial_conditions_WOA23/make_initial_conditions.sh
+++ b/initial_conditions_WOA23/make_initial_conditions.sh
@@ -2,47 +2,116 @@
 # Copyright 2025 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
 # SPDX-License-Identifier: Apache-2.0
 
-#PBS -q normal
-#PBS -l mem=64Gb
-#PBS -l walltime=48:00:00
-#PBS -l jobfs=400GB
-#PBS -l ncpus=8
-#PBS -l wd
-#PBS -l storage=gdata/xp65+gdata/ik11+gdata/tm70+gdata/vk83
+# This script submits 12 jobs to the pbs scheduler, one for each month
 
 HGRID=$HGRID
 VGRID=$VGRID
 INPUT_DIR=$INPUT_DIR
 OUTPUT_DIR=$OUTPUT_DIR
 
-module purge
-module use /g/data/xp65/public/modules
-module load conda/analysis3
+# ---------------------------------
+# Usage
+# ---------------------------------
+usage() {
+    cat <<EOF
+This script submits 12 jobs to the pbs scheduler, one for each month to make initial conditions from world ocean atlas
+
+Usage: $0 -h <hgrid> -v <vgrid> -i <input_dir> -o <output_dir>
+
+Required arguments:
+  -h, --hgrid        Horizontal grid size
+  -v, --vgrid        Vertical grid size
+  -i, --input        Input directory
+  -o, --output       Output directory
+
+Example:
+   ./make_initial_conditions.sh --vgrid /g/data/vk83/configurations/inputs/access-om3/mom/grids/vertical/global.25km/2025.03.12/ocean_vgrid.nc --hgrid /g/data/x77/ahg157/inputs/mom6/global-8km/ocean_hgrid.nc --input /g/data/ik11/inputs/access-om3/woa23/monthly/2025.10.24 --output /g/data/tm70/cyb561/8km_woa_ic 
+EOF
+    exit 1
+}
+
+# ---------------------------------
+# Parse arguments
+# ---------------------------------
+[[ $# -eq 0 ]] && { echo "Error: No arguments provided."; usage; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--hgrid)
+            HGRID="$2"
+            shift 2
+            ;;
+        -v|--vgrid)
+            VGRID="$2"
+            shift 2
+            ;;
+        -i|--input)
+            INPUT_DIR="$2"
+            shift 2
+            ;;
+        -o|--output)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        -help|--help|-H)
+            usage
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            usage
+            ;;
+    esac
+done
+
+# ---------------------------------
+# Validate required arguments
+# ---------------------------------
+[[ -z "$HGRID" ]]      && { echo "Error: --hgrid is required."; usage; }
+[[ -z "$VGRID" ]]      && { echo "Error: --vgrid is required."; usage; }
+[[ -z "$INPUT_DIR" ]]  && { echo "Error: --input is required."; usage; }
+[[ -z "$OUTPUT_DIR" ]] && { echo "Error: --output is required."; usage; }
+
+# ---------------------------------
+# Export or use variables
+# ---------------------------------
+export HGRID VGRID INPUT_DIR OUTPUT_DIR
+
+echo "Passed arguments are"
+echo "HGRID=$HGRID"
+echo "VGRID=$VGRID"
+echo "INPUT_DIR=$INPUT_DIR"
+echo "OUTPUT_DIR=$OUTPUT_DIR"
+
+echo "All required arguments parsed successfully."
+
+# Create output directory if it doesn't exist
+mkdir -p "${OUTPUT_DIR}"
+
+#this loop cycles over each month and submits a pbs job associated with each month
+for ((i=1; i<=12; i++))
+do
+
+printf -v mon "%02d" "${i}"
+INPUT_FILE="${INPUT_DIR}/woa23_decav_ts_${mon}_04.nc"
+OUTPUT_FILE="${OUTPUT_DIR}/woa23_ts_${mon}_mom.nc"
+echo ""
+echo "Month, INPUT_FILE, OUTPUT_FILE: "
+echo "${mon}, ${INPUT_FILE}, ${OUTPUT_FILE}"
+echo ""
+
+mkdir -p $i
+cp -v submit_jobs_initial_conditions.sh $i/
+
+cd $i
+ln -sf "${INPUT_FILE}" input.nc
 
 # Link grid files
 ln -sf ${HGRID} ocean_hgrid.nc
 ln -sf ${VGRID} ocean_vgrid.nc
 
-PATH=./ocean-ic/:$PATH
-echo $PATH
+##SUBMIT the job 
+qsub -v VGRID="${VGRID}",HGRID="${HGRID}",INPUT_DIR="${INPUT_DIR}",OUTPUT_DIR="${OUTPUT_DIR}",OUTPUT_FILE="${OUTPUT_FILE}",INPUT_FILE="${INPUT_FILE}" -P $PROJECT submit_jobs_initial_conditions.sh
 
-# Create output directory if it doesn't exist
-mkdir -p "${OUTPUT_DIR}"
-
-# Process each month
-for ((i=1; i<=12; i++))
-do
-    printf -v mon "%02d" "${i}"
-    INPUT_FILE="${INPUT_DIR}/woa23_decav_ts_${mon}_04.nc"
-    OUTPUT_FILE="${OUTPUT_DIR}/woa23_ts_${mon}_mom.nc"
-
-    echo "Processing: ${INPUT_FILE}"
-    ln -sf "${INPUT_FILE}" input.nc
-
-    makeic.py --use_mpi --mom_version MOM6 WOA input.nc input.nc input.nc input.nc MOM ocean_hgrid.nc ocean_vgrid.nc "${OUTPUT_FILE}"
-
-    ncatted -h -O -a input_file,global,o,c,"$INPUT_FILE (md5sum: $(md5sum $INPUT_FILE | cut -f 1 -d ' '))" $OUTPUT_FILE
-    ncatted -h -O -a ocean_hgrid_file,global,o,c,"$HGRID (md5sum: $(md5sum $HGRID | cut -f 1 -d ' '))" $OUTPUT_FILE
-    ncatted -h -O -a ocean_vgrid_file,global,o,c,"$VGRID (md5sum: $(md5sum $VGRID | cut -f 1 -d ' '))" $OUTPUT_FILE
+cd ..
 
 done

--- a/initial_conditions_WOA23/submit_jobs_initial_conditions.sh
+++ b/initial_conditions_WOA23/submit_jobs_initial_conditions.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Copyright 2025 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
+#PBS -q normal
+#PBS -l mem=64Gb
+#PBS -l walltime=22:00:00
+#PBS -l jobfs=400GB
+#PBS -l ncpus=8
+#PBS -l wd
+#PBS -l storage=gdata/xp65+gdata/ik11+gdata/tm70+gdata/vk83+gdata/x77
+
+#passed grid and io information
+HGRID=$HGRID
+VGRID=$VGRID
+INPUT_DIR=$INPUT_DIR
+OUTPUT_DIR=$OUTPUT_DIR
+
+#for each month input/output files
+INPUT_FILE=$INPUT_FILE
+OUTPUT_FILE=$OUTPUT_FILE
+
+echo "Passed arguments are: "
+echo "HGRID=$HGRID"
+echo "VGRID=$VGRID"
+echo "INPUT_DIR=$INPUT_DIR"
+echo "OUTPUT_DIR=$OUTPUT_DIR"
+echo "INPUT_FILE=$INPUT_FILE"
+echo "OUTPUT_FILE=$OUTPUT_FILE"
+
+module purge
+module use /g/data/xp65/public/modules
+module load conda/analysis3
+
+PATH=../ocean-ic/:$PATH
+echo $PATH
+
+makeic.py --use_mpi --mom_version MOM6 WOA input.nc input.nc input.nc input.nc MOM ocean_hgrid.nc ocean_vgrid.nc "${OUTPUT_FILE}"
+
+ncatted -h -O -a input_file,global,o,c,"$INPUT_FILE (md5sum: $(md5sum $INPUT_FILE | cut -f 1 -d ' '))" $OUTPUT_FILE
+ncatted -h -O -a ocean_hgrid_file,global,o,c,"$HGRID (md5sum: $(md5sum $HGRID | cut -f 1 -d ' '))" $OUTPUT_FILE
+ncatted -h -O -a ocean_vgrid_file,global,o,c,"$VGRID (md5sum: $(md5sum $VGRID | cut -f 1 -d ' '))" $OUTPUT_FILE


### PR DESCRIPTION
Closes [#12](https://github.com/ACCESS-NRI/initial_conditions_access-om3/issues/12).

> New initial conditions and restoring files are needed for dev-MC_8km_jra_ryf but the global 8km grid is large enough that we can't loop through each month and have it complete in a single job (queue limit is 48 hours).

> This issue / related PR is to parralise the make_initial_conditions.sh script by month.